### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "types": "dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "solid": "./dist/source/index.jsx",
       "import": "./dist/esm/index.js",
       "browser": "./dist/esm/index.js",


### PR DESCRIPTION
Fix a typescript error : There are types at '', but this result could not be resolved when respecting package.json "exports". The 'solid-moon-toast' library may need to update its package.json or typings.